### PR TITLE
Allow customer notification via WhatsApp Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ $ flask run
 $ uvicorn main.py
 ```
 ## API Endpoints for this Project
-Microservice endpoint for this API available [here](https://example.com/country-capital/<query-params>).
+Microservice endpoint for this API available [here](https://example.com/country-capital/<query-params>) for your reference.


### PR DESCRIPTION
Customers have been requesting the ability to get
notified about product updates via their WhatsApp number.
This mode of notification is optional, but if specified, should cause
notifications to go out both on their emails as well as WhatsApp numbers.